### PR TITLE
Update to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ readme = "README.md"
 keywords = ["steam", "id", "steamid", "parser"]
 categories = ["parser-implementations", "games"]
 license = "MIT"
+edition = "2018"
 
 [dependencies]
 enum_primitive = "0.1.1"
-serde_derive = "1.0.106"
 lazy_static = "1.4.0"
-serde = "1.0.106"
+serde = { version = "1.0.106", features = ["derive"] }
 regex = "1.3.6"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ readme = "README.md"
 keywords = ["steam", "id", "steamid", "parser"]
 categories = ["parser-implementations", "games"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 enum_primitive = "0.1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,12 +29,6 @@
 
 #[macro_use]
 extern crate enum_primitive;
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate lazy_static;
-extern crate regex;
-extern crate serde;
 
 use std::{
     error::Error,
@@ -43,8 +37,12 @@ use std::{
 };
 
 use enum_primitive::FromPrimitive;
+use lazy_static::lazy_static;
 use regex::Regex;
-use serde::de::{self, Deserialize, Deserializer, Visitor};
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Default, Serialize)]
 pub struct SteamID(u64);


### PR DESCRIPTION
This just updates the crate to follow the 2018 edition. There weren't too many changes since this crate is pretty small to begin with

We could bump up to the 2021 edition, but I opted for just 2018 since the 2021 edition is still rather recent (a little over half a year old)