### PR TITLE
Remove dependency on regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,6 @@ enum_primitive = "0.1.1"
 serde = { version = "1.0.106", features = ["derive"] }
 
 [dev-dependencies]
-lazy_static = "1.4.0"
-proptest = "1.0.0"
-regex = "1.5.6"
 serde_json = "1.0.51"
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,7 @@ rust-version = "1.56"
 
 [dependencies]
 enum_primitive = "0.1.1"
-lazy_static = "1.4.0"
 serde = { version = "1.0.106", features = ["derive"] }
-regex = "1.3.6"
 
 [dev-dependencies]
 serde_json = "1.0.51"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ enum_primitive = "0.1.1"
 serde = { version = "1.0.106", features = ["derive"] }
 
 [dev-dependencies]
+lazy_static = "1.4.0"
+proptest = "1.0.0"
+regex = "1.5.6"
 serde_json = "1.0.51"
 
 [badges]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,13 +230,7 @@ impl SteamID {
         }
 
         let mut account_id = u32::from(digit_from_ascii(bytes.next()?)?);
-        let mut num_digits = 1;
         while let Some(digit) = bytes.peek().copied().and_then(digit_from_ascii) {
-            num_digits += 1;
-            if num_digits > 10 {
-                return None;
-            }
-
             bytes.next().expect("Byte was peeked");
             account_id = account_id.checked_mul(10)?;
             account_id = account_id.checked_add(u32::from(digit))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,8 +152,8 @@ impl SteamID {
         }
         let mut account_id = u32::from(digit_from_ascii(bytes.next()?)?);
         for b in bytes {
-            account_id *= 10;
-            account_id += u32::from(digit_from_ascii(b)?);
+            account_id = account_id.checked_mul(10)?;
+            account_id = account_id.checked_add(u32::from(digit_from_ascii(b)?))?;
         }
         let account_id = account_id << 1 | auth_server;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,6 @@ use std::{
 };
 
 use enum_primitive::FromPrimitive;
-use lazy_static::lazy_static;
-use regex::Regex;
 use serde::{
     de::{self, Visitor},
     Deserialize, Deserializer, Serialize,
@@ -46,6 +44,14 @@ use serde::{
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Default, Serialize)]
 pub struct SteamID(u64);
+
+fn digit_from_ascii(byte: u8) -> Option<u8> {
+    if (b'0'..=b'9').contains(&byte) {
+        Some(byte - b'0')
+    } else {
+        None
+    }
+}
 
 impl SteamID {
     pub fn account_id(&self) -> u32 {
@@ -108,45 +114,50 @@ impl SteamID {
         }
     }
 
-    /// Little ergonomics thing, to avoid typing `SteamIDParseError::default()` everywhere
-    fn err() -> SteamIDParseError {
-        Default::default()
+    pub fn from_steam2(steam2: &str) -> Result<Self, SteamIDParseError> {
+        Self::from_steam2_helper(steam2).ok_or(SteamIDParseError {})
     }
 
-    pub fn from_steam2(steam2: &str) -> Result<Self, SteamIDParseError> {
-        lazy_static! {
-            static ref STEAM2_REGEX: Regex =
-                Regex::new(r"^STEAM_([0-4]):([0-1]):([0-9]{1,10})$").unwrap();
-        }
+    // Parses id in the format of:
+    // ^STEAM_(universe:[0-4]):(auth_server:[0-1]):(account_id:[0-9]{1,10})$
+    fn from_steam2_helper(steam2: &str) -> Option<Self> {
+        let chunk = steam2.strip_prefix("STEAM_")?;
+        let mut bytes = chunk.bytes();
 
-        let groups = STEAM2_REGEX.captures(steam2).ok_or_else(Self::err)?;
-
-        let mut universe: Universe = Universe::from_u64(
-            groups
-                .get(1)
-                .ok_or_else(Self::err)?
-                .as_str()
-                .parse()
-                .unwrap(),
-        )
-        .ok_or_else(Self::err)?;
-        let auth_server: u32 = groups
-            .get(2)
-            .ok_or_else(Self::err)?
-            .as_str()
-            .parse()
-            .unwrap();
-        #[cfg_attr(rustfmt, rustfmt_skip)]
-        let account_id: u32 = groups.get(3).ok_or_else(Self::err)?.as_str().parse().unwrap();
-        let account_id = account_id << 1 | auth_server;
-
+        let mut universe: Universe = bytes
+            .next()
+            .and_then(|b| Universe::from_u64(u64::from(digit_from_ascii(b)?)))?;
         // Apparently, games before orange box used to display as 0 incorrectly
         // This is only an issue with steam2 ids
         if let Universe::Invalid = universe {
             universe = Universe::Public;
         }
 
-        Ok(Self::new(
+        if bytes.next() != Some(b':') {
+            return None;
+        }
+
+        let auth_server: u32 = match bytes.next()? {
+            b'0' => Some(0),
+            b'1' => Some(1),
+            _ => None,
+        }?;
+
+        if bytes.next() != Some(b':') {
+            return None;
+        }
+
+        if bytes.len() > 10 {
+            return None;
+        }
+        let mut account_id = u32::from(digit_from_ascii(bytes.next()?)?);
+        for b in bytes {
+            account_id *= 10;
+            account_id += u32::from(digit_from_ascii(b)?);
+        }
+        let account_id = account_id << 1 | auth_server;
+
+        Some(Self::new(
             account_id,
             Instance::Desktop,
             AccountType::Individual,
@@ -184,57 +195,86 @@ impl SteamID {
     }
 
     pub fn from_steam3(steam3: &str) -> Result<Self, SteamIDParseError> {
-        lazy_static! {
-            static ref STEAM3_REGEX: Regex =
-                Regex::new(r"^\[([AGMPCgcLTIUai]):([0-4]):([0-9]{1,10})(:([0-9]+))?\]$").unwrap();
+        Self::from_steam3_helper(steam3).ok_or(SteamIDParseError {})
+    }
+
+    // Parses id in the format of:
+    // ^\[(type:[AGMPCgcLTIUai]):(universe:[0-4]):(account_id:[0-9]{1,10})(:(instance:[0-9]+))?\]$
+    fn from_steam3_helper(steam3: &str) -> Option<Self> {
+        let mut bytes = steam3.bytes().peekable();
+
+        if bytes.next() != Some(b'[') {
+            return None;
         }
 
-        let groups = STEAM3_REGEX.captures(steam3).ok_or_else(Self::err)?;
-
-        let type_char = groups
-            .get(1)
-            .ok_or_else(Self::err)?
-            .as_str()
-            .chars()
-            .next()
-            .unwrap();
+        let type_char = char::from(bytes.next()?);
         let (account_type, flag) = char_to_account_type(type_char);
-        let universe = Universe::from_u64(
-            groups
-                .get(2)
-                .ok_or_else(Self::err)?
-                .as_str()
-                .parse()
-                .unwrap(),
-        )
-        .ok_or_else(Self::err)?;
-        let account_id = groups
-            .get(3)
-            .ok_or_else(Self::err)?
-            .as_str()
-            .parse()
-            .unwrap();
-
-        let mut instance: Option<Instance> = groups
-            .get(5)
-            .map(|g| Instance::from_u64(g.as_str().parse().unwrap()).unwrap_or(Instance::Invalid));
-
-        if instance.is_none() && type_char == 'U' {
-            instance = Some(Instance::Desktop);
-        } else if type_char == 'T' || type_char == 'g' || instance.is_none() {
-            instance = Some(Instance::All);
+        if type_char != 'i' && type_char != 'I' && account_type == AccountType::Invalid {
+            return None;
         }
+
+        if bytes.next() != Some(b':') {
+            return None;
+        }
+
+        let universe = bytes.next().and_then(digit_from_ascii).and_then(|digit| {
+            if digit <= 4 {
+                Universe::from_u64(u64::from(digit))
+            } else {
+                None
+            }
+        })?;
+
+        if bytes.next() != Some(b':') {
+            return None;
+        }
+
+        let mut account_id = u32::from(digit_from_ascii(bytes.next()?)?);
+        let mut num_digits = 1;
+        while let Some(digit) = bytes.peek().copied().and_then(digit_from_ascii) {
+            num_digits += 1;
+            if num_digits > 10 {
+                return None;
+            }
+
+            bytes.next().expect("Byte was peeked");
+            account_id = account_id.checked_mul(10)?;
+            account_id = account_id.checked_add(u32::from(digit))?;
+        }
+
+        // Instance is optional. Parse it if it's there, but leave the closing ] intact
+        let mut instance = {
+            let maybe_instance = if bytes.peek() == Some(&b':') {
+                bytes.next().expect("Byte was peeked");
+
+                let mut acc = u64::from(digit_from_ascii(bytes.next()?)?);
+                while let Some(digit) = bytes.peek().copied().and_then(digit_from_ascii) {
+                    bytes.next().expect("Byte was peeked");
+                    acc = acc.checked_mul(10)?;
+                    acc = acc.checked_add(u64::from(digit))?;
+                }
+
+                Some(Instance::from_u64(acc).unwrap_or(Instance::Invalid))
+            } else {
+                None
+            };
+
+            match (maybe_instance, type_char) {
+                (None, 'U') => Instance::Desktop,
+                (None, _) | (_, 'T' | 'g') => Instance::All,
+                (Some(instance), _) => instance,
+            }
+        };
 
         if let Some(i) = flag {
-            instance = Some(i);
+            instance = i;
         }
 
-        Ok(Self::new(
-            account_id,
-            instance.ok_or_else(Self::err)?,
-            account_type,
-            universe,
-        ))
+        if bytes.next() != Some(b']') {
+            return None;
+        }
+
+        Some(Self::new(account_id, instance, account_type, universe))
     }
 }
 

--- a/tests/regresssions.rs
+++ b/tests/regresssions.rs
@@ -1,0 +1,6 @@
+use steamid_ng::SteamID;
+
+#[test]
+fn steam2_overflowing_account_id() {
+    let _ = SteamID::from_steam2("STEAM_0:0:9999999999");
+}

--- a/tests/regresssions.rs
+++ b/tests/regresssions.rs
@@ -1,6 +1,0 @@
-use steamid_ng::SteamID;
-
-#[test]
-fn steam2_overflowing_account_id() {
-    let _ = SteamID::from_steam2("STEAM_0:0:9999999999");
-}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,3 @@
-use lazy_static::lazy_static;
-use proptest::{prelude::*, proptest};
-use regex::Regex;
 use steamid_ng::*;
 
 #[test]
@@ -214,36 +211,4 @@ fn test_debug_print() {
         debug,
         "SteamID(157626004137848889) {ID: 12345, Instance: Web, Type: GameServer, Universe: Beta}"
     );
-}
-
-proptest! {
-    // Runs reasonable fast, so use more cases
-    #![proptest_config(ProptestConfig {
-        cases: 1_000,
-        ..ProptestConfig::default()
-    })]
-
-    #[test]
-    fn from_steam2_regex(s in "\\PC*") {
-        lazy_static! {
-            static ref STEAM2_REGEX: Regex =
-                Regex::new(r"^STEAM_([0-4]):([0-1]):([0-9]{1,10})$").unwrap();
-        }
-
-        let is_valid_by_regex = STEAM2_REGEX.captures(&s).is_some();
-        let is_valid_by_manual = SteamID::from_steam2(&s).is_ok();
-        assert_eq!(is_valid_by_regex, is_valid_by_manual);
-    }
-
-    #[test]
-    fn from_steam3_regex(s in "\\PC*") {
-        lazy_static! {
-            static ref STEAM3_REGEX: Regex =
-                Regex::new(r"^\[([AGMPCgcLTIUai]):([0-4]):([0-9]{1,10})(:([0-9]+))?\]$").unwrap();
-        }
-
-        let is_valid_by_regex = STEAM3_REGEX.captures(&s).is_some();
-        let is_valid_by_manual = SteamID::from_steam2(&s).is_ok();
-        assert_eq!(is_valid_by_regex, is_valid_by_manual);
-    }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -212,3 +212,8 @@ fn test_debug_print() {
         "SteamID(157626004137848889) {ID: 12345, Instance: Web, Type: GameServer, Universe: Beta}"
     );
 }
+
+#[test]
+fn steam2_overflowing_account_id() {
+    let _ = SteamID::from_steam2("STEAM_0:0:9999999999");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,6 @@
-extern crate serde_json;
-extern crate steamid_ng;
+use lazy_static::lazy_static;
+use proptest::{prelude::*, proptest};
+use regex::Regex;
 use steamid_ng::*;
 
 #[test]
@@ -213,4 +214,36 @@ fn test_debug_print() {
         debug,
         "SteamID(157626004137848889) {ID: 12345, Instance: Web, Type: GameServer, Universe: Beta}"
     );
+}
+
+proptest! {
+    // Runs reasonable fast, so use more cases
+    #![proptest_config(ProptestConfig {
+        cases: 1_000,
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn from_steam2_regex(s in "\\PC*") {
+        lazy_static! {
+            static ref STEAM2_REGEX: Regex =
+                Regex::new(r"^STEAM_([0-4]):([0-1]):([0-9]{1,10})$").unwrap();
+        }
+
+        let is_valid_by_regex = STEAM2_REGEX.captures(&s).is_some();
+        let is_valid_by_manual = SteamID::from_steam2(&s).is_ok();
+        assert_eq!(is_valid_by_regex, is_valid_by_manual);
+    }
+
+    #[test]
+    fn from_steam3_regex(s in "\\PC*") {
+        lazy_static! {
+            static ref STEAM3_REGEX: Regex =
+                Regex::new(r"^\[([AGMPCgcLTIUai]):([0-4]):([0-9]{1,10})(:([0-9]+))?\]$").unwrap();
+        }
+
+        let is_valid_by_regex = STEAM3_REGEX.captures(&s).is_some();
+        let is_valid_by_manual = SteamID::from_steam2(&s).is_ok();
+        assert_eq!(is_valid_by_regex, is_valid_by_manual);
+    }
 }


### PR DESCRIPTION
This PR removes the dependency on both `lazy_static` and `regex` by hand-rolling parsers for the steam2 and steam3 id formats. This unsurprisingly makes the parsing more complicated, but I would say that the regexes were straightforward enough that things are still decently simple.

Property tests with the old regexes were added to verify that the new parsers still accept the same inputs as the regexes did before

This change drops the number of dependencies pulled in by this library from 16 to 11 :partying_face: 