### PR TITLE
Rename AccountType enum value 9 to match Steamworks SDK

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,7 +408,7 @@ pub enum AccountType {
     ContentServer = 6,
     Clan = 7,
     Chat = 8,
-    P2PSuperSeeder = 9,
+    ConsoleUser = 9,
     AnonUser = 10,
 }
 
@@ -425,7 +425,7 @@ impl TryFrom<u8> for AccountType {
             6 => Ok(AccountType::ContentServer),
             7 => Ok(AccountType::Clan),
             8 => Ok(AccountType::Chat),
-            9 => Ok(AccountType::P2PSuperSeeder),
+            9 => Ok(AccountType::ConsoleUser),
             10 => Ok(AccountType::AnonUser),
             _ => Err(SteamIDParseError),
         }
@@ -447,8 +447,8 @@ pub fn account_type_to_char(account_type: AccountType, flags: InstanceFlags) -> 
             InstanceFlags::Lobby => 'L',
             _ => 'T',
         },
+        AccountType::ConsoleUser => 'U',
         AccountType::AnonUser => 'a',
-        AccountType::P2PSuperSeeder => 'i', // Invalid (?)
     }
 }
 


### PR DESCRIPTION
Renaming AccountType enum value 9 "ConsoleUser" to align with Valve's official Steamworks SDK (v1.62 - 14 March 2025) definition (k_EAccountTypeConsoleUser).

According to the SDK, this represents a "Fake SteamID for local PSN account on PS3 or Live account on 360, etc."

Proof:
<img width="1238" height="718" alt="image" src="https://github.com/user-attachments/assets/e29a3113-1606-4fd1-965c-1ec167a33401" />

<img width="1626" height="466" alt="image" src="https://github.com/user-attachments/assets/ef94605a-bfda-4612-92f4-9a247b1bc4a1" />
